### PR TITLE
Add support for Dockerised building + Win32 fixes

### DIFF
--- a/src/makefile.dockerdist
+++ b/src/makefile.dockerdist
@@ -1,0 +1,204 @@
+# Copyright (c) 2009-2010 Satoshi Nakamoto
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+USE_UPNP:=1
+USE_IPV6:=1
+LIB_DIR:=/usr/lib
+
+LINK:=$(CXX)
+ARCH:=$(system lscpu | head -n 1 | awk '{print $2}')
+
+DEFS=-DBOOST_SPIRIT_THREADSAFE
+
+DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/obj $(BOOST_INCLUDE_PATH) $(BDB_INCLUDE_PATH) $(OPENSSL_INCLUDE_PATH))
+LIBS = $(addprefix -L,$(BOOST_LIB_PATH) $(BDB_LIB_PATH) $(OPENSSL_LIB_PATH))
+
+LMODE = dynamic
+LMODE2 = dynamic
+ifdef STATIC
+	LMODE = static
+	ifeq (${STATIC}, all)
+		LMODE2 = static
+	endif
+endif
+
+# for boost 1.37, add -mt to the boost libraries
+LIBS += \
+ -Wl,-B$(LMODE) \
+   $(LIB_DIR)/libboost_system.a \
+   $(LIB_DIR)/libboost_filesystem.a \
+   $(LIB_DIR)/libboost_program_options.a \
+   $(LIB_DIR)/libboost_thread.a \
+   $(LIB_DIR)/libdb_cxx.a \
+   $(LIB_DIR)/libssl.a \
+   $(LIB_DIR)/libcrypto.a
+
+ifndef USE_UPNP
+	override USE_UPNP = -
+endif
+ifneq (${USE_UPNP}, -)
+	LIBS +=  $(LIB_DIR)/libminiupnpc.a
+	DEFS += -DUSE_UPNP=$(USE_UPNP)
+endif
+
+ifneq (${USE_IPV6}, -)
+	DEFS += -DUSE_IPV6=$(USE_IPV6)
+endif
+
+LIBS+= \
+ -Wl,-B$(LMODE2) \
+   $(LIB_DIR)/libz.a \
+   -l dl \
+   -l pthread
+
+
+# Hardening
+# Make some classes of vulnerabilities unexploitable in case one is discovered.
+#
+    # This is a workaround for Ubuntu bug #691722, the default -fstack-protector causes
+    # -fstack-protector-all to be ignored unless -fno-stack-protector is used first.
+    # see: https://bugs.launchpad.net/ubuntu/+source/gcc-4.5/+bug/691722
+    HARDENING=-fno-stack-protector
+
+    # Stack Canaries
+    # Put numbers at the beginning of each stack frame and check that they are the same.
+    # If a stack buffer if overflowed, it writes over the canary number and then on return
+    # when that number is checked, it won't be the same and the program will exit with
+    # a "Stack smashing detected" error instead of being exploited.
+    HARDENING+=-fstack-protector-all -Wstack-protector
+
+    # Make some important things such as the global offset table read only as soon as
+    # the dynamic linker is finished building it. This will prevent overwriting of addresses
+    # which would later be jumped to.
+    LDHARDENING+=-Wl,-z,relro -Wl,-z,now
+
+    # Build position independent code to take advantage of Address Space Layout Randomization
+    # offered by some kernels.
+    # see doc/build-unix.txt for more information.
+    ifdef PIE
+        HARDENING+=-fPIE
+        LDHARDENING+=-pie
+    endif
+
+    # -D_FORTIFY_SOURCE=2 does some checking for potentially exploitable code patterns in
+    # the source such overflowing a statically defined buffer.
+    HARDENING+=-D_FORTIFY_SOURCE=2
+#
+
+
+DEBUGFLAGS=-g
+
+
+ifeq (${ARCH}, i686)
+	EXT_OPTIONS=-msse2
+endif
+
+
+# CXXFLAGS can be specified on the make command line, so we use xCXXFLAGS that only
+# adds some defaults in front. Unfortunately, CXXFLAGS=... $(CXXFLAGS) does not work.
+xCXXFLAGS=-O2 $(EXT_OPTIONS) -pthread -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter \
+    $(DEBUGFLAGS) $(DEFS) $(HARDENING) $(CXXFLAGS)
+
+# LDFLAGS can be specified on the make command line, so we use xLDFLAGS that only
+# adds some defaults in front. Unfortunately, LDFLAGS=... $(LDFLAGS) does not work.
+xLDFLAGS=$(LDHARDENING) $(LDFLAGS)
+
+OBJS= \
+    obj/groestl.o \
+    obj/blake.o \
+    obj/bmw.o \
+    obj/skein.o \
+    obj/keccak.o \
+    obj/shavite.o \
+    obj/jh.o \
+    obj/luffa.o \
+    obj/cubehash.o \
+    obj/echo.o \
+    obj/simd.o \
+    obj/alert.o \
+    obj/version.o \
+    obj/checkpoints.o \
+    obj/netbase.o \
+    obj/addrman.o \
+    obj/crypter.o \
+    obj/key.o \
+    obj/db.o \
+    obj/init.o \
+    obj/irc.o \
+    obj/keystore.o \
+    obj/miner.o \
+    obj/main.o \
+    obj/net.o \
+    obj/protocol.o \
+    obj/bitcoinrpc.o \
+    obj/rpcdump.o \
+    obj/rpcnet.o \
+    obj/rpcmining.o \
+    obj/rpcwallet.o \
+    obj/rpcblockchain.o \
+    obj/rpcrawtransaction.o \
+    obj/script.o \
+    obj/sync.o \
+    obj/util.o \
+    obj/wallet.o \
+    obj/walletdb.o \
+    obj/noui.o \
+    obj/kernel.o \
+    obj/pbkdf2.o \
+    obj/scrypt.o \
+    obj/scrypt-arm.o \
+    obj/scrypt-x86.o \
+    obj/scrypt-x86_64.o
+
+all: bumbacoin2d
+
+LIBS += $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a
+DEFS += $(addprefix -I,$(CURDIR)/leveldb/include)
+DEFS += $(addprefix -I,$(CURDIR)/leveldb/helpers)
+OBJS += obj/txdb-leveldb.o
+leveldb/libleveldb.a:
+	@echo "Building LevelDB ..."; cd leveldb; make libleveldb.a libmemenv.a; cd ..;
+obj/txdb-leveldb.o: leveldb/libleveldb.a
+
+# auto-generated dependencies:
+-include obj/*.P
+
+obj/build.h: FORCE
+	/bin/sh ../share/genbuild.sh obj/build.h
+version.cpp: obj/build.h
+DEFS += -DHAVE_BUILD_INFO
+
+obj/scrypt-x86.o: scrypt-x86.S
+	$(CXX) -c $(xCXXFLAGS) -MMD -o $@ $<
+
+obj/scrypt-x86_64.o: scrypt-x86_64.S
+	$(CXX) -c $(xCXXFLAGS) -MMD -o $@ $<
+
+obj/scrypt-arm.o: scrypt-arm.S
+	$(CXX) -c $(xCXXFLAGS) -MMD -o $@ $<
+	
+obj/%.o: %.c
+	$(CXX) -c $(xCXXFLAGS) -fpermissive -MMD -MF $(@:%.o=%.d) -o $@ $<
+	@cp $(@:%.o=%.d) $(@:%.o=%.P); \
+	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
+	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
+	rm -f $(@:%.o=%.d)
+
+obj/%.o: %.cpp
+	$(CXX) -c $(xCXXFLAGS) -MMD -MF $(@:%.o=%.d) -o $@ $<
+	@cp $(@:%.o=%.d) $(@:%.o=%.P); \
+	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
+	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
+	  rm -f $(@:%.o=%.d)
+
+bumbacoin2d: $(OBJS:obj/%=obj/%)
+	$(LINK) $(xCXXFLAGS) -o $@ $^ $(xLDFLAGS) $(LIBS)
+
+clean:
+	-rm -f bumbacoin2d
+	-rm -f obj/*.o
+	-rm -f obj/*.P
+	-rm -f obj/build.h
+
+FORCE:

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -4,7 +4,7 @@
 
 TARGET_PLATFORM:=i686
 #TARGET_PLATFORM:=x86_64
-LIB_DIR:=/deps/mingw-u686
+LIB_DIR:=/deps/mingw-i686
 CC:=$(TARGET_PLATFORM)-w64-mingw32-gcc
 CXX:=$(TARGET_PLATFORM)-w64-mingw32-g++
 RANLIB=$(TARGET_PLATFORM)-w64-mingw32-ranlib

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -4,8 +4,7 @@
 
 TARGET_PLATFORM:=i686
 #TARGET_PLATFORM:=x86_64
-
-DEPSDIR:=/usr/$(TARGET_PLATFORM)-w64-mingw32
+LIB_DIR:=/deps/mingw-u686
 CC:=$(TARGET_PLATFORM)-w64-mingw32-gcc
 CXX:=$(TARGET_PLATFORM)-w64-mingw32-g++
 RANLIB=$(TARGET_PLATFORM)-w64-mingw32-ranlib
@@ -17,15 +16,10 @@ USE_IPV6:=1
 INCLUDEPATHS= \
  -I"$(CURDIR)" \
  -I"$(CURDIR)"/obj \
- -I"$(DEPSDIR)/boost_1_55_0" \
- -I"$(DEPSDIR)/db-6.0.20/build_unix" \
- -I"$(DEPSDIR)/openssl-1.0.1f/include" \
- -I"$(DEPSDIR)"
+ -I"$(LIB_DIR)/include"
 
 LIBPATHS= \
- -L"$(DEPSDIR)/boost_1_55_0/stage/lib" \
- -L"$(DEPSDIR)/db-6.0.20/build_unix" \
- -L"$(DEPSDIR)/openssl-1.0.1f"
+ -L"$(LIB_DIR)/lib" 
 
 LIBS= \
  -l boost_system-mt \
@@ -40,7 +34,7 @@ LIBS= \
 DEFS=-D_MT -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB -DBOOST_SPIRIT_THREADSAFE
 DEBUGFLAGS=-g
 CFLAGS=-O3 -msse2 -w -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
-LDFLAGS=-Wl,--dynamicbase -Wl,--nxcompat -static-libgcc -static-libstdc++
+LDFLAGS=-Wl,--dynamicbase -Wl,--nxcompat -static-libgcc -static-libstdc++ -static
 
 ifndef USE_UPNP
 	override USE_UPNP = -

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -22,14 +22,15 @@ LIBPATHS= \
  -L"$(LIB_DIR)/lib" 
 
 LIBS= \
- -l boost_system \
- -l boost_filesystem \
- -l boost_program_options \
- -l boost_thread_win32 \
- -l boost_chrono \
- -l db_cxx \
- -l ssl \
- -l crypto
+ "$(LIB_DIR)/lib/libboost_system.a" \
+ "$(LIB_DIR)/lib/libboost_filesystem.a" \
+ "$(LIB_DIR)/lib/libboost_program_options.a" \
+ "$(LIB_DIR)/lib/libboost_thread_w32.a" \
+ "$(LIB_DIR)/lib/libboost_chrono.a" \
+ "$(LIB_DIR)/lib/libdb_cxx.a" \
+ "$(LIB_DIR)/lib/libssl.a" \
+ "$(LIB_DIR)/lib/libcrypto.a" \
+ "$(LIB_DIR)/lib/libminiupnpc.a"
 
 DEFS=-D_MT -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB -DBOOST_SPIRIT_THREADSAFE
 DEBUGFLAGS=-g
@@ -38,11 +39,6 @@ LDFLAGS=-Wl,--dynamicbase -Wl,--nxcompat -static-libgcc -static-libstdc++ -stati
 
 ifndef USE_UPNP
 	override USE_UPNP = -
-endif
-ifneq (${USE_UPNP}, -)
-	LIBPATHS += -L"$(DEPSDIR)/miniupnpc"
-	LIBS += -l miniupnpc -l iphlpapi
-	DEFS += -DSTATICLIB -DUSE_UPNP=$(USE_UPNP)
 endif
 
 ifneq (${USE_IPV6}, -)

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -51,6 +51,17 @@ LIBS += -l mingwthrd -l kernel32 -l user32 -l gdi32 -l comdlg32 -l winspool -l w
 HEADERS = $(wildcard *.h)
 
 OBJS= \
+    obj/groestl.o \
+    obj/blake.o \
+    obj/bmw.o \
+    obj/skein.o \
+    obj/keccak.o \
+    obj/shavite.o \
+    obj/jh.o \
+    obj/luffa.o \
+    obj/cubehash.o \
+    obj/echo.o \
+    obj/simd.o \
     obj/alert.o \
     obj/version.o \
     obj/checkpoints.o \

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -30,7 +30,8 @@ LIBS= \
  "$(LIB_DIR)/lib/libdb_cxx.a" \
  "$(LIB_DIR)/lib/libssl.a" \
  "$(LIB_DIR)/lib/libcrypto.a" \
- "$(LIB_DIR)/lib/libminiupnpc.a"
+ "$(LIB_DIR)/lib/libminiupnpc.a" \
+ "$(LIB_DIR)/lib/libpthreadGC2.a"
 
 DEFS=-D_MT -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB -DBOOST_SPIRIT_THREADSAFE
 DEBUGFLAGS=-g

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -114,6 +114,9 @@ DEFS += -DHAVE_BUILD_INFO
 obj/%.o: %.cpp $(HEADERS)
 	$(CXX) -c $(CFLAGS) -o $@ $<
 
+obj/%.o: %.c 
+	$(CC) -c $(CFLAGS) -o $@ $<
+
 bumbacoin2d.exe: $(OBJS:obj/%=obj/%)
 	$(CXX) $(CFLAGS) $(LDFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS) -lshlwapi
 	$(STRIP) bumbacoin2d.exe

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -22,11 +22,11 @@ LIBPATHS= \
  -L"$(LIB_DIR)/lib" 
 
 LIBS= \
- -l boost_system-mt \
- -l boost_filesystem-mt \
- -l boost_program_options-mt \
- -l boost_thread_win32-mt \
- -l boost_chrono-mt \
+ -l boost_system \
+ -l boost_filesystem \
+ -l boost_program_options \
+ -l boost_thread_win32 \
+ -l boost_chrono \
  -l db_cxx \
  -l ssl \
  -l crypto

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -25,7 +25,7 @@ LIBS= \
  "$(LIB_DIR)/lib/libboost_system.a" \
  "$(LIB_DIR)/lib/libboost_filesystem.a" \
  "$(LIB_DIR)/lib/libboost_program_options.a" \
- "$(LIB_DIR)/lib/libboost_thread_w32.a" \
+ "$(LIB_DIR)/lib/libboost_thread_win32.a" \
  "$(LIB_DIR)/lib/libboost_chrono.a" \
  "$(LIB_DIR)/lib/libdb_cxx.a" \
  "$(LIB_DIR)/lib/libssl.a" \

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3,7 +3,9 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#if !defined(_WIN32)
 #include <sys/resource.h>
+#endif
 
 #include "util.h"
 #include "sync.h"


### PR DESCRIPTION
This PR includes an additional Makefile used by the Docker automated build process. This commit also allows binaries being built from Linux for Windows, making it possible to have a single release workflow.